### PR TITLE
Updated: Nuget Spec to NOT try to get packages from now protected MS …

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -5,11 +5,5 @@
 	</solution>
 	<packageSources>
 		<add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
-		<add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-		<add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
-		<add key="aspnet-aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
-		<add key="aspnet-aspnetcore-tooling" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json" />
-		<add key="aspnet-entityframeworkcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-entityframeworkcore/index.json" />
-		<add key="aspnet-extensions" value="https://dotnetfeed.blob.core.windows.net/aspnet-extensions/index.json" />
 	</packageSources>
 </configuration>

--- a/SpanJson.Benchmarks/SpanJson.Benchmarks.csproj
+++ b/SpanJson.Benchmarks/SpanJson.Benchmarks.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageReference Include="Jil" Version="2.17.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />

--- a/SpanJson.Tests/SpanJson.Tests.csproj
+++ b/SpanJson.Tests/SpanJson.Tests.csproj
@@ -15,11 +15,11 @@
 
   <ItemGroup>
     <PackageReference Include="Jil" Version="2.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.3" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
-    <PackageReference Include="xunit" Version="2.8.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/SpanJson.WebBenchmark/SpanJson.WebBenchmark.csproj
+++ b/SpanJson.WebBenchmark/SpanJson.WebBenchmark.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Jil" Version="2.17.0" />
-    <PackageReference Include="System.Memory" Version="4.6.0-preview1-26717-04" />
+    <PackageReference Include="System.Memory" Version="4.6.2" />
     <PackageReference Include="Utf8Json" Version="1.3.7" />
   </ItemGroup>
 


### PR DESCRIPTION
I needed these updates in order to just be able to build and test this repo...

Updated: Nuget Spec to NOT try to get packages from now protected MS Sources.
Updated: Nuget Packages and in Particular we no longer try to get a specific System.Memory Package preview that no longer exists